### PR TITLE
Fix OpenAI client initialization for httpx 0.28

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 sqlmodel==0.0.14
 openai==1.3.7
+httpx<0.28
 requests==2.31.0
 beautifulsoup4==4.12.2
 jinja2==3.1.2


### PR DESCRIPTION
## Summary
- load environment variables when starting OpenAI client
- patch OpenAI's httpx usage so it works with httpx 0.28
- pin httpx version in requirements

## Testing
- `python backend/main.py` *(fails: Directory 'static' does not exist)*
- `mkdir -p static assets`
- `python backend/main.py` *(shows startup warnings and exits)*

------
https://chatgpt.com/codex/tasks/task_e_6889da36b8688329a1c51fb0f97dcdf3